### PR TITLE
mark sale on rd station after checkout

### DIFF
--- a/app/code/local/Flowecommerce/Resultadosdigitais/Helper/Data.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Helper/Data.php
@@ -6,6 +6,10 @@ class Flowecommerce_Resultadosdigitais_Helper_Data extends Mage_Core_Helper_Abst
         return Mage::getStoreConfig('resultadosdigitais/general/token');
     }
 
+    public function getPrivateToken() {
+    	return Mage::getStoreConfig('resultadosdigitais/general/private_token');
+    }
+
     public function isEnabled() {
         return Mage::getStoreConfigFlag('resultadosdigitais/general/enable');
     }

--- a/app/code/local/Flowecommerce/Resultadosdigitais/Model/Api.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Model/Api.php
@@ -1,12 +1,35 @@
-<?php
+a<?php
 
 class Flowecommerce_Resultadosdigitais_Model_Api
 {
 
-    const API_URL = 'http://www.rdstation.com.br/api/1.2/conversions';
+    const API_URL = 'https://www.rdstation.com.br/api/1.2/conversions';
 
     protected $_helper = null;
     protected $_httpClient = null;
+
+    public function markSale($email, $value)
+    {
+        try {
+            $data = array(
+                'status'      => 'won',
+                'value'       => $value,
+                'email'       => $email,
+            );
+            $token = $this->_getHelper()->getPrivateToken();
+            $url = "https://www.rdstation.com.br/api/1.2/services/{$token}/generic";
+            $leadHttpClient = $this->_getHttpClient();
+            $leadHttpClient
+                ->resetParameters()
+                ->setUri($url)
+                ->setMethod(Zend_Http_Client::POST)
+                ->setParameterPost($data);
+            $response = $leadHttpClient->request();
+            $responseBody = $response->getBody();
+        } catch (Exception $e) {
+            Mage::logException($e);
+        }
+    }
 
     public function addLeadConversion($conversionIdentifier, Flowecommerce_Resultadosdigitais_Model_Requestdata $data)
     {

--- a/app/code/local/Flowecommerce/Resultadosdigitais/Model/Observer.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Model/Observer.php
@@ -5,17 +5,17 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
     protected $_api    = null;
     protected $_helper = null;
 
-	/**
-	 * Tipos de lead
-	 */
+    /**
+     * Tipos de lead
+     */
     const LEAD_CONTACTFORM          = 'contact-form';
     const LEAD_ORDERPLACE           = 'order-place';
     const LEAD_ACCOUNTCREATE        = 'account-create';
     const LEAD_NEWSLETTERSUBSCRIBE  = 'newsletter-subscribe';
 
-	/**
-	 * Cliente tipo pessoa juridica - Compatibilidade com módulo PJ Flow
-	 */
+    /**
+     * Cliente tipo pessoa juridica - Compatibilidade com módulo PJ Flow
+     */
     const FPJ_PESSOA_JURIDICA_TYPE = 2;
 
     protected function _getApi() {
@@ -72,6 +72,8 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
             /* @var Mage_Sales_Model_Order_Address $address */
             $address = $order->getBillingAddress();
 
+            $order_value = $order->getGrandTotal();
+
             /*
              * Dados da conta
              */
@@ -81,7 +83,6 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
             $data->setAniversario($customer->getDob());
             $data->setGender($this->_getGenderLabel($customer->getGender()));
             $data->setCpfCnpj($customer->getTaxvat());
-
 
             /*
              * Dados do endereço
@@ -110,12 +111,13 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
                 /* @var Mage_Directory_Model_Region $region */
                 $region = Mage::getModel('directory/region')->load($regionId);
                 $uf = $region->getName();
+                if ($uf) {
+                    $data->setUf($uf);
+                }
             }
-            if ($uf) {
-                $data->setUf($uf);
-            }
-
+            
             $this->_getApi()->addLeadConversion(self::LEAD_ORDERPLACE, $data);
+            $this->_getApi()->markSale($customer->getEmail(), $order_value);
         }
     }
 

--- a/app/code/local/Flowecommerce/Resultadosdigitais/etc/system.xml
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/etc/system.xml
@@ -40,6 +40,14 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </token>
+                        <private_token translate="label">
+                            <label>Token Privado</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </private_token>
                     </fields>
                 </general>
             </groups>


### PR DESCRIPTION
Marcar venda com valor no RD Station conforme [documentação do RD Station](http://ajuda.rdstation.com.br/hc/pt-br/articles/202640385-Marcar-venda-e-lost-via-formul%C3%A1rio-pr%C3%B3prio-ou-sistema-API-) .

@gabrielqs após a inclusão da função `markSale`, não existe o redirecionamento para a página de confirmação de place order. Podes me ajudar com isso? 

Mesmo assim, a venda é computada no Magento e a conversão e a marcação de venda são enviadas para o RD.
