### PR TITLE
Add store view name in conversions

### DIFF
--- a/app/code/local/Flowecommerce/Resultadosdigitais/Model/Observer.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Model/Observer.php
@@ -49,6 +49,10 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
         return Mage::getModel('resultadosdigitais/requestdata');
     }
 
+    protected function _getStoreDataObject() {
+        return Mage::app()->getStore();
+    }
+
     public function contactPost(Varien_Event_Observer $observer) {
         if ($this->_getHelper()->isEnabled()) {
             $data = $observer->getData();

--- a/app/code/local/Flowecommerce/Resultadosdigitais/Model/Observer.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Model/Observer.php
@@ -62,6 +62,8 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
             $data->setEmail($post['email']);
             $data->setNome($post['name']);
             $data->setTelefone($post['telephone']);
+            
+            $data->setData('store_name', $this->_getStoreDataObject()->getName());
 
             $this->_getApi()->addLeadConversion(self::LEAD_CONTACTFORM, $data);
         }
@@ -151,6 +153,7 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
             $data->setData('produto__categoria', implode(', ', $categoryNames));
             $data->setData('metodo_pagamento', $order->getPayment()->getMethod());
             $data->setData('metodo_entrega', $order->getShippingMethod());
+            $data->setData('store_name', $this->_getStoreDataObject()->getName());
 
             $this->_getApi()->addLeadConversion(self::LEAD_ORDERPLACE, $data);
             $this->_getApi()->markSale($customer->getEmail(), $order_value);
@@ -171,6 +174,8 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
             $data->setAniversario($customer->getDob());
             $data->setGender($this->_getGenderLabel($customer->getGender()));
             $data->setCpfCnpj($customer->getTaxvat());
+            
+            $data->setData('store_name', $this->_getStoreDataObject()->getName());
 
             $this->_getApi()->addLeadConversion(self::LEAD_ACCOUNTCREATE, $data);
         }
@@ -185,6 +190,8 @@ class Flowecommerce_Resultadosdigitais_Model_Observer {
                  */
                 $data = $this->_getRequestDataObject();
                 $data->setEmail($subscriber->getEmail());
+                
+                $data->setData('store_name', $this->_getStoreDataObject()->getName());
 
                 $this->_getApi()->addLeadConversion(self::LEAD_NEWSLETTERSUBSCRIBE, $data);
             }


### PR DESCRIPTION
Objetivo do PR é adicionar a informação de nome da loja do magento nas conversões com o RDStation. Necessidade surgiu de usuários do RDStation que possuem mais de uma loja integrada no RDStation e desta forma não conseguiam diferenciar as conversões. Dessa forma usuário pode segmentar base por meio de campo personalizado store_name, para criar campanhas e fluxos especificos para cada loja. 

Para testar basta acionar os gatilhos que geram as conversoes. Info de store name deve ser inclusa em todas conversões.