### PR TITLE
Inserir TrafficSource

### DIFF
--- a/app/code/local/Flowecommerce/Resultadosdigitais/Model/Api.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Model/Api.php
@@ -89,6 +89,10 @@ class Flowecommerce_Resultadosdigitais_Model_Api
         if ($utmz = $tracker->getUtmZString()) {
             $return['c_utmz'] = $utmz;
         }
+        
+        if (!empty($_COOKIE['__trf_src'])) {
+    	    $return['traffic_source'] = $_COOKIE['__trf_src'];
+        }
 
         return $return;
     }


### PR DESCRIPTION
Insere o valor do cookie __trf.src quando existe. O RDStation fornece um script para gerar este cookie, que é utilizado para pegar a origem de tráfego quando não está disponível via utmz.