### PR TITLE
Include lead tracking cookie for Lead visits

### DIFF
--- a/app/code/local/Flowecommerce/Resultadosdigitais/Model/Api.php
+++ b/app/code/local/Flowecommerce/Resultadosdigitais/Model/Api.php
@@ -93,6 +93,10 @@ class Flowecommerce_Resultadosdigitais_Model_Api
         if (!empty($_COOKIE['__trf_src'])) {
     	    $return['traffic_source'] = $_COOKIE['__trf_src'];
         }
+        
+        if (!empty($_COOKIE['rdtrk'])) {
+    	    $return['client_id'] = json_decode($_COOKIE['rdtrk'])->{'id'};
+        }
 
         return $return;
     }


### PR DESCRIPTION
Inclusão do cookie rdtrk responsável pelo Lead Tracking. @gabrielqs veja se esta função json_decode faz sentido de acordo com a lib do magento por favor, é um código padrão que usamos pra leitura desse cookie em php. 